### PR TITLE
Format JS with Prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,5 @@ insert_final_newline = true
 [*.{js,py,md,css,j2,html,yaml,sh,toml}]
 charset = utf-8
 
-[*.{html,js,yaml}]
+[*.{html,yaml}]
 indent_size = 2

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 4,
+  "useTabs": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/silicon/static/js/edit.js
+++ b/silicon/static/js/edit.js
@@ -4,89 +4,92 @@ var editor = {
     submit_clicked: false,
 };
 
-if (silicon_editor === 'codemirror') {
+if (silicon_editor === "codemirror") {
     var cm_instance;
 }
 
 function usurp_unload(e) {
     e.preventDefault();
-    e.returnValue = '';
+    e.returnValue = "";
 }
 
-window.addEventListener("load", function() {
+window.addEventListener("load", function () {
     // load CodeMirror instance
-    if (silicon_editor === 'codemirror') {
+    if (silicon_editor === "codemirror") {
         require.config({
-            baseUrl: js_modules_root
+            baseUrl: js_modules_root,
         });
 
         require([
-        "lib/codemirror",
-        "mode/markdown/markdown",
-        "mode/clike/clike",
-        "mode/css/css",
-        "mode/diff/diff",
-        "mode/dockerfile/dockerfile",
-        "mode/gfm/gfm",
-        "mode/htmlmixed/htmlmixed",
-        "mode/jinja2/jinja2",
-        "mode/python/python",
-        "mode/shell/shell",
-        "mode/sql/sql",
-        "mode/yaml/yaml",
-        "addon/display/fullscreen",
-        "addon/display/panel",
-        ].map(x => `codemirror/${x}`), function(CodeMirror) {
-            cm_instance = CodeMirror.fromTextArea(document.querySelector('#body-text'), {
-                mode: {
-                    name: 'gfm',
-                    gitHubSpice: false,
-                },
-                lineSeparator: '\n',
-                lineWrapping: true,
-                extraKeys: {
-                    // home/end shouldn't go to the beginning/end of paragraphs
-                    Home: 'goLineLeft',
-                    End: 'goLineRight',
-                    // do not redefine the browser history navigation keys
-                    'Alt-Left': false,
-                    'Alt-Right': false
-                },
-                autofocus: true,
-                // appears to do nothing
-                spellcheck: true,
-                viewportMargin: Infinity,
-            });
+            "lib/codemirror",
+            "mode/markdown/markdown",
+            "mode/clike/clike",
+            "mode/css/css",
+            "mode/diff/diff",
+            "mode/dockerfile/dockerfile",
+            "mode/gfm/gfm",
+            "mode/htmlmixed/htmlmixed",
+            "mode/jinja2/jinja2",
+            "mode/python/python",
+            "mode/shell/shell",
+            "mode/sql/sql",
+            "mode/yaml/yaml",
+            "addon/display/fullscreen",
+            "addon/display/panel",
+        ].map((x) => `codemirror/${x}`), function (CodeMirror) {
+            cm_instance = CodeMirror.fromTextArea(
+                document.querySelector("#body-text"),
+                {
+                    mode: {
+                        name: "gfm",
+                        gitHubSpice: false,
+                    },
+                    lineSeparator: "\n",
+                    lineWrapping: true,
+                    extraKeys: {
+                        // home/end shouldn't go to the beginning/end of paragraphs
+                        Home: "goLineLeft",
+                        End: "goLineRight",
+                        // do not redefine the browser history navigation keys
+                        "Alt-Left": false,
+                        "Alt-Right": false,
+                    },
+                    autofocus: true,
+                    // appears to do nothing
+                    spellcheck: true,
+                    viewportMargin: Infinity,
+                }
+            );
         });
     }
 
     // mark the editor as changed if there is an alert shown
     // (implies there was an error saving)
-    if (document.querySelector('#alerts') !== null) {
+    if (document.querySelector("#alerts") !== null) {
         editor.changed = true;
-    };
+    }
 
     // mark the editor as changed if the textarea has changed
-    document.querySelector('#body-text')
-        .addEventListener('input', (event) => editor.changed = true);
+    document
+        .querySelector("#body-text")
+        .addEventListener("input", (event) => (editor.changed = true));
 
     // don't nag if the Submit button was clicked
-    document.querySelector('#page-form').onsubmit = function() {
+    document.querySelector("#page-form").onsubmit = function () {
         editor.submit_clicked = true;
     };
 
-    window.addEventListener('beforeunload', function (e) {
-        if (silicon_editor === 'codemirror') {
+    window.addEventListener("beforeunload", function (e) {
+        if (silicon_editor === "codemirror") {
             // alert on changed codemirror
-            if ((! cm_instance.isClean() && ! editor.submit_clicked)) {
+            if (!cm_instance.isClean() && !editor.submit_clicked) {
                 usurp_unload(e);
             }
         } else {
             // alert on changed textarea
-            if ((editor.changed && ! editor.submit_clicked)) {
+            if (editor.changed && !editor.submit_clicked) {
                 usurp_unload(e);
-            };
+            }
         }
     });
-
 });

--- a/silicon/static/js/main.js
+++ b/silicon/static/js/main.js
@@ -1,11 +1,14 @@
-window.addEventListener("load", function() {
+window.addEventListener("load", function () {
     /* Toggle nav sidebar in "mobile" mode */
-    document.querySelector("[data-toggle='nav-top']")
-        .addEventListener('click', (event) => {
-            const elements = document.querySelectorAll("[data-toggle='nav-shift']");
+    document
+        .querySelector("[data-toggle='nav-top']")
+        .addEventListener("click", (event) => {
+            const elements = document.querySelectorAll(
+                "[data-toggle='nav-shift']"
+            );
 
-            elements.forEach(function(element) {
-                element.classList.toggle('shift');
-            })
-        })
+            elements.forEach(function (element) {
+                element.classList.toggle("shift");
+            });
+        });
 });

--- a/silicon/static/js/widgets.js
+++ b/silicon/static/js/widgets.js
@@ -13,7 +13,7 @@ function get_widget(target) {
 
     return {
         element: widget_element,
-        url: widget_element.getAttribute("data-widget-url")
+        url: widget_element.getAttribute("data-widget-url"),
     };
 }
 
@@ -21,7 +21,8 @@ function get_widget(target) {
  * Set up relation add button event.
  */
 function relation_add_button() {
-    document.querySelector("#add-relation-btn")
+    document
+        .querySelector("#add-relation-btn")
         .addEventListener("click", (event) => {
             const relative = window.prompt("Related page title");
 
@@ -33,24 +34,27 @@ function relation_add_button() {
             const widget = get_widget("#related-links");
             fetch(widget.url, {
                 method: "POST",
-                body: new URLSearchParams({relative: relative}),
+                body: new URLSearchParams({ relative: relative }),
                 headers: new Headers({
-                    "Content-type": "application/x-www-form-urlencoded; charset=UTF-8"
+                    "Content-type":
+                        "application/x-www-form-urlencoded; charset=UTF-8",
+                }),
+            })
+                .then((response) => {
+                    if (response.ok) {
+                        return response.text();
+                    }
+                    throw new Error(
+                        `Error fetching ${response.url}, got ${response.status}`
+                    );
                 })
-            })
-            .then(response => {
-                if (response.ok) {
-                    return response.text();
-                }
-                throw new Error(`Error fetching ${response.url}, got ${response.status}`);
-            })
-            .then(html => {
-                widget.element.innerHTML = html;
-                relation_delete_buttons();
-            })
-            .catch(err => {
-                console.error(err);
-            });
+                .then((html) => {
+                    widget.element.innerHTML = html;
+                    relation_delete_buttons();
+                })
+                .catch((err) => {
+                    console.error(err);
+                });
         });
 }
 
@@ -58,27 +62,30 @@ function relation_add_button() {
  * Set up relation delete button events.
  */
 function relation_delete_buttons() {
-    const del_btns = document.querySelectorAll(".del-relation-btn")
+    const del_btns = document.querySelectorAll(".del-relation-btn");
     const widget = get_widget("#related-links");
 
-    del_btns.forEach(function(btn) {
+    del_btns.forEach(function (btn) {
         const relative = btn.getAttribute("data-del-relative");
         btn.addEventListener("click", (event) => {
-            const answer = window.confirm(`Delete this page's relationship to ${relative}?`);
+            const answer = window.confirm(
+                `Delete this page's relationship to ${relative}?`
+            );
             if (answer === true) {
                 fetch(`${widget.url}/${relative}`, {
                     method: "DELETE",
-                }).then(response => {
-                    return response.text();
-                }).then(html => {
-                    widget.element.innerHTML = html;
-                    relation_delete_buttons();
                 })
+                    .then((response) => {
+                        return response.text();
+                    })
+                    .then((html) => {
+                        widget.element.innerHTML = html;
+                        relation_delete_buttons();
+                    });
             }
         });
     });
 }
-
 
 /*
  * Set up the table of contents update button.
@@ -89,49 +96,51 @@ function toc_update_button() {
         return;
     }
 
-    document.querySelector("#update-toc").style.visibility = 'visible';
+    document.querySelector("#update-toc").style.visibility = "visible";
 
-    document.querySelector("#update-toc-btn")
-        .addEventListener("click", (event => {
+    document
+        .querySelector("#update-toc-btn")
+        .addEventListener("click", (event) => {
             const widget = get_widget("#toc");
             // get the contents of CodeMirror, or the textarea
             let body_text;
             if (document.querySelector(".CodeMirror")) {
-                body_text = document.querySelector(".CodeMirror").CodeMirror.getValue();
+                body_text = document
+                    .querySelector(".CodeMirror")
+                    .CodeMirror.getValue();
             } else {
                 body_text = document.querySelector("#body-text").value;
             }
 
             fetch(widget.url, {
                 method: "POST",
-                body: new URLSearchParams(
-                    {body: body_text}
-                ),
+                body: new URLSearchParams({ body: body_text }),
                 headers: new Headers({
-                    "Content-type": "application/x-www-form-urlencoded; charset=UTF-8"
+                    "Content-type":
+                        "application/x-www-form-urlencoded; charset=UTF-8",
+                }),
+            })
+                .then((response) => {
+                    if (response.ok) {
+                        return response.text();
+                    }
+                    throw new Error(
+                        `Error fetching ${response.url}, got ${response.status}`
+                    );
                 })
-            })
-            .then(response => {
-                if (response.ok) {
-                    return response.text();
-                }
-                throw new Error(`Error fetching ${response.url}, got ${response.status}`);
-            })
-            .then(html => {
-                widget.element.innerHTML = html;
-            })
-            .catch(err => {
-                console.error(err);
-            });
-
-        }));
+                .then((html) => {
+                    widget.element.innerHTML = html;
+                })
+                .catch((err) => {
+                    console.error(err);
+                });
+        });
 }
-
 
 /*
  * Set up all the page events.
  */
-window.addEventListener("load", function() {
+window.addEventListener("load", function () {
     relation_add_button();
     relation_delete_buttons();
     toc_update_button();


### PR DESCRIPTION
Having a .prettierrc means anybody who uses format-on-save will automatically follow project conventions. I used 2-space tabs because that's what you put in .editorconfig, and otherwise just left all the default settings alone.

A step further would be to add a CI job which fails if the submitter _doesn’t_ use the formatter, but I'll let you decide if you want to go that far. I'd be happy to write the config file to make that happen.

I included a vscode config to make it more likely that future contributors do the right thing. I didn't realize until #17 that it also formats CSS, so hopefully that's OK. I can scope it down to just JS if necessary.