### PR TITLE
Don’t format-on-save for anything but JS and CSS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,15 @@
 {
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "[javascript]": {
+        "editor.formatOnSave": true
+    },
+    "[css]": {
+        "editor.formatOnSave": true
+    },
+    "[markdown]": {
+        "editor.formatOnSave": false
+    },
+    "[python]": {
+        "editor.formatOnSave": false
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
My vscode wanted to format your README.md, which seemed silly.

I could set these settings at the workspace level and not commit them to the repo if config changes are annoying, it just seems harmless to maintain a consistent config for everyone.