### PR TITLE
MD_HARD_WRAP option to allow differences in opinion about line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ docs, but these are some you might care to know about:
   (and write it to a file in `INSTANCE_PATH`) if one doesn't exist.
 * `SILICON_EDITOR`: When set to `textarea`, this disables the CodeMirror text
 editor when editing pages and uses a standard textarea element instead.
+* `MD_HARD_WRAP`: When set to `true`, all line breaks are converted to `<br>`
+  tags. By default, you must suffix a line with two spaces (`  `) to get a
+  `<br>`.
 
 To initialize the database after the configuration settings have been set,
 run the following command. It will create an `instance` directory in the root

--- a/silicon/render_md.py
+++ b/silicon/render_md.py
@@ -1,3 +1,4 @@
+import os
 from flask import url_for
 from mistune import create_markdown, HTMLRenderer
 from mistune.util import safe_entity
@@ -111,6 +112,7 @@ def md_renderer(text):
     """Render a Markdown document into HTML."""
 
     markdown = create_markdown(
+        hard_wrap=(os.getenv('MD_HARD_WRAP') or "").lower() == "true",
         renderer=CustomRenderer(escape=False),
         plugins=[
             'strikethrough',


### PR DESCRIPTION
Markdown's line break rules are not universally loved, so here's a config option to let people choose their preference. (...it's me I like it the other way.)