### PR TITLE
Views for pages with slugs will always redirect to the canonical slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,23 +332,6 @@ This is pretty standard on wiki-like apps, but it's not a critical feature
 for me so I haven't yet mustered up the fortitude to implement it. (It would
 also likely involve adding a diff library as a dependency.)
 
-## Redirect to Slugified URL
-
-We currently "slugify" the page title in at least two places:
-
-1. When building the URL for an internal page link generated from wiki link
-syntax `[[like this]]` in `render.py`.
-2. When processing requests with page titles in the URLs for certain routes in
-`views.py`.
-
-In the second case, page titles are slugified immediately, meaning every
-instance of the page title is slugified in the HTML. However, the URL will
-still contain the non-slugified title. This is pretty much purely cosmetic,
-but it would be nice if the application could immediately redirect to a
-slugified page title instead, if necessary.
-
-I found lots of ugly ways to do this but nothing I was comfortable shipping.
-
 ## Draft Feature / Autosave / Leap-frog Detection
 
 To prevent the loss of unsaved changes while editing, we use the browser's

--- a/silicon/views.py
+++ b/silicon/views.py
@@ -30,7 +30,11 @@ def home():
 
 @bp.route('/view/<title>')
 def view(title):
-    title = slugify_title(title)
+    slugified_title = slugify_title(title)
+
+    if slugified_title != title:
+        return redirect(url_for("page.view", title=slugified_title))
+
     if 'revision' in request.args:
         p = page.read(title, request.args.get('revision'))
     else:
@@ -48,7 +52,11 @@ def view(title):
 
 @bp.route('/edit/<title>', methods=['GET', 'POST'])
 def edit(title):
-    title = slugify_title(title)
+    slugified_title = slugify_title(title)
+
+    if slugified_title != title:
+        return redirect(url_for("page.edit", title=slugified_title))
+
     p = page.read(title)
     p['relatives'] = related.get(title)
     if 'body' in p:

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -94,10 +94,7 @@ def test_url_title_gets_slugified(client, page):
     raw_title = "a b-c|d:e=f+g"  # not exhaustive
     for route in ("/view/", "/edit/"):
         r = client.get(route + raw_title)
-        print(route)
-        assert (
-            str(page(r.data).find(class_="page-title").string)
-            == "a_b_c_d_e_f_g")
+        assert r.location.endswith("/a_b_c_d_e_f_g")
 
 
 def test_page_timestamp(client, page):


### PR DESCRIPTION
This method requires maybe too much copypasta for hypothetical new endpoints. I also considered a couple other options which would make the call sites fail unless they do things correctly

```py
(slugified_title, was_equal) = slugify_title(title)
if not was_equal:
    return redirect(...)
```

```py
try:
    title = slugify_title(title)
except SlugMismatch as e:
    return redirect(...) # where SlugMismatch has the slug value
```

```py
@with_slugified_url(key='title', make_url=lambda title: url_for('page.xxx', title=title'))
def view(title):
  # ...
```

...but these seemed like overkill.